### PR TITLE
New Metrocluster option

### DIFF
--- a/AsBuiltReport.NetApp.ONTAP.json
+++ b/AsBuiltReport.NetApp.ONTAP.json
@@ -10,7 +10,8 @@
     },
     "Options": {
         "Exclude": {
-            "Vserver": []
+            "Vserver": [],
+            "MetroCluster" : false
         }
     },
     "InfoLevel": {

--- a/AsBuiltReport.NetApp.ONTAP.json
+++ b/AsBuiltReport.NetApp.ONTAP.json
@@ -11,7 +11,7 @@
     "Options": {
         "Exclude": {
             "Vserver": [],
-            "MetroCluster" : false
+            "MetroCluster": false
         }
     },
     "InfoLevel": {

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The **Options** schema allows certain options within the report to be toggled on
 | Sub-Schema      | Setting      | Default | Description |
 |-----------------|--------------|---------|-----------------------------------------------------------------|
 | Exclude: Vserver | Array List  | Empty    | Allow to filter on Vserver Name
+| Exclude: MetroCluster | true / false   | false    | Allow to filter automatically all Vserver with -mc
 
 ### InfoLevel
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ The ONTAP Storage As Built Report supports the following ONTAP versions;
 
 This report is compatible with the following PowerShell versions;
 
-| PowerShell 5.1 | PowerShell 7 | 
-|:----------------------:|:---------------:|
-|   :white_check_mark:   |   :white_check_mark:|
+|   PowerShell 5.1   |    PowerShell 7    |
+| :----------------: | :----------------: |
+| :white_check_mark: | :white_check_mark: |
 
 ## :wrench: System Requirements
 
@@ -68,10 +68,10 @@ Each of the following modules will be automatically installed by following the [
 These modules may also be manually installed.
 
 | Module Name        | Minimum Required Version |                              PS Gallery                               |                                   GitHub                                    |
-|--------------------|:------------------------:|:---------------------------------------------------------------------:|:---------------------------------------------------------------------------:|
+| ------------------ | :----------------------: | :-------------------------------------------------------------------: | :-------------------------------------------------------------------------: |
 | PScribo            |          0.9.1           |      [Link](https://www.powershellgallery.com/packages/PScribo)       |         [Link](https://github.com/iainbrighton/PScribo/tree/master)         |
 | AsBuiltReport.Core |          1.2.0           | [Link](https://www.powershellgallery.com/packages/AsBuiltReport.Core) | [Link](https://github.com/AsBuiltReport/AsBuiltReport.Core/releases/latest) |
-| Netapp.ONTAP |          9.10.1.2111           | [Link](https://www.powershellgallery.com/packages/NetApp.ONTAP) |  |
+| Netapp.ONTAP       |       9.10.1.2111        |    [Link](https://www.powershellgallery.com/packages/NetApp.ONTAP)    |                                                                             |
 
 ## :package: Module Installation
 
@@ -124,23 +124,23 @@ The following provides information of how to configure each schema within the re
 
 The **Report** schema provides configuration of the NetApp ONTAP report information.
 
-| Sub-Schema          | Setting      | Default                        | Description                                                  |
-|---------------------|--------------|--------------------------------|--------------------------------------------------------------|
-| Name                | User defined | NetApp ONTAP As Built Report   | The name of the As Built Report                              |
-| Version             | User defined | 1.0                            | The report version                                           |
-| Status              | User defined | Released                       | The report release status                                    |
-| ShowCoverPageImage  | true / false | true                           | Toggle to enable/disable the display of the cover page image |
-| ShowTableOfContents | true / false | true                           | Toggle to enable/disable table of contents                   |
-| ShowHeaderFooter    | true / false | true                           | Toggle to enable/disable document headers & footers          |
-| ShowTableCaptions   | true / false | true                           | Toggle to enable/disable table captions/numbering            |
+| Sub-Schema          | Setting      | Default                      | Description                                                  |
+| ------------------- | ------------ | ---------------------------- | ------------------------------------------------------------ |
+| Name                | User defined | NetApp ONTAP As Built Report | The name of the As Built Report                              |
+| Version             | User defined | 1.0                          | The report version                                           |
+| Status              | User defined | Released                     | The report release status                                    |
+| ShowCoverPageImage  | true / false | true                         | Toggle to enable/disable the display of the cover page image |
+| ShowTableOfContents | true / false | true                         | Toggle to enable/disable table of contents                   |
+| ShowHeaderFooter    | true / false | true                         | Toggle to enable/disable document headers & footers          |
+| ShowTableCaptions   | true / false | true                         | Toggle to enable/disable table captions/numbering            |
 
 ### Options
 
 The **Options** schema allows certain options within the report to be toggled on or off.
-| Sub-Schema      | Setting      | Default | Description |
-|-----------------|--------------|---------|-----------------------------------------------------------------|
-| Exclude: Vserver | Array List  | Empty    | Allow to filter on Vserver Name
-| Exclude: MetroCluster | true / false   | false    | Allow to filter automatically all Vserver with -mc
+| Sub-Schema            | Setting      | Default | Description                                        |
+| --------------------- | ------------ | ------- | -------------------------------------------------- |
+| Exclude: Vserver      | Array List   | Empty   | Allow to filter on Vserver Name                    |
+| Exclude: MetroCluster | true / false | false   | Allow to filter automatically all Vserver with -mc |
 
 ### InfoLevel
 
@@ -148,26 +148,26 @@ The **InfoLevel** schema allows configuration of each section of the report at a
 
 There are 3 levels (0-2) of detail granularity for each section as follows;
 
-| Setting | InfoLevel         | Description                                                                                                                                |
-|:-------:|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-|    0    | Disabled          | Does not collect or display any information                                                                                                |
-|    1    | Enabled / Summary | Provides summarised information for a collection of objects                                                                                |
-|    2    | Adv Summary       | Provides condensed, detailed information for a collection of objects                                                                       |
+| Setting | InfoLevel         | Description                                                          |
+| :-----: | ----------------- | -------------------------------------------------------------------- |
+|    0    | Disabled          | Does not collect or display any information                          |
+|    1    | Enabled / Summary | Provides summarised information for a collection of objects          |
+|    2    | Adv Summary       | Provides condensed, detailed information for a collection of objects |
 
 The table below outlines the default and maximum **InfoLevel** settings for each section.
 
-| Sub-Schema   | Default Setting | Maximum Setting |
-|--------------|:---------------:|:---------------:|
-| Cluster       |        1        |        2        |
-| Node       |        1        |        2        |
-| Storage          |        1        |        2        |
-| Network         |        1        |        2        |
-| License           |        1        |        2        |
-| Vserver           |        1        |        2        |
-| Efficiency           |        1        |        2        |
-| Security           |        1        |        2        |
-| System           |        1        |        2        |
-| Replication           |        1        |        2        |
+| Sub-Schema  | Default Setting | Maximum Setting |
+| ----------- | :-------------: | :-------------: |
+| Cluster     |        1        |        2        |
+| Node        |        1        |        2        |
+| Storage     |        1        |        2        |
+| Network     |        1        |        2        |
+| License     |        1        |        2        |
+| Vserver     |        1        |        2        |
+| Efficiency  |        1        |        2        |
+| Security    |        1        |        2        |
+| System      |        1        |        2        |
+| Replication |        1        |        2        |
 
 ### Healthcheck
 

--- a/Src/Public/Invoke-AsBuiltReport.NetApp.ONTAP.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.NetApp.ONTAP.ps1
@@ -71,7 +71,7 @@ function Invoke-AsBuiltReport.NetApp.ONTAP {
 
         #If metrocluster option remove all -mc vserver
         if ($Options.Exclude.MetroCluster) {
-            $Options.Exclude.Vserver = $Options.Exclude.Vserver + (get-ncvserver |where-object {$_ -like '*-mc'}).Vserver
+            $Options.Exclude.Vserver = $Options.Exclude.Vserver + (Get-NcVserver | Where-Object { $_ -like '*-mc' }).Vserver
             $exclude_vserver = $Options.Exclude.Vserver
             Write-PScriboMessage "exclude vserver = $exclude_vserver"
         }

--- a/Src/Public/Invoke-AsBuiltReport.NetApp.ONTAP.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.NetApp.ONTAP.ps1
@@ -69,6 +69,13 @@ function Invoke-AsBuiltReport.NetApp.ONTAP {
         }
         $ClusterInfo = Get-NcCluster -Controller $Array
 
+        #If metrocluster option remove all -mc vserver
+        if ($Options.Exclude.MetroCluster) {
+            $Options.Exclude.Vserver = $Options.Exclude.Vserver + (get-ncvserver |where {$_ -like '*-mc'}).Vserver
+            $exclude_vserver = $Options.Exclude.Vserver
+            Write-PScriboMessage "exclude vserver = $exclude_vserver"
+        }
+
         #---------------------------------------------------------------------------------------------#
         #                                 Cluster Section                                             #
         #---------------------------------------------------------------------------------------------#

--- a/Src/Public/Invoke-AsBuiltReport.NetApp.ONTAP.ps1
+++ b/Src/Public/Invoke-AsBuiltReport.NetApp.ONTAP.ps1
@@ -71,7 +71,7 @@ function Invoke-AsBuiltReport.NetApp.ONTAP {
 
         #If metrocluster option remove all -mc vserver
         if ($Options.Exclude.MetroCluster) {
-            $Options.Exclude.Vserver = $Options.Exclude.Vserver + (get-ncvserver |where {$_ -like '*-mc'}).Vserver
+            $Options.Exclude.Vserver = $Options.Exclude.Vserver + (get-ncvserver |where-object {$_ -like '*-mc'}).Vserver
             $exclude_vserver = $Options.Exclude.Vserver
             Write-PScriboMessage "exclude vserver = $exclude_vserver"
         }


### PR DESCRIPTION
Provide new feature to improve Metrocluster FC Support

## Description
In metrocluster FMCC we have vserver with name ending by -mc that are normaly stopped
with this new option we can  autoremove vserver with -mc information.
we use the $Options.Exclude.Vserver and add -mc vserver automatically

## Related Issue
Fix #40 

## Motivation and Context
Automatically add exclusion on standby Vserver

## How Has This Been Tested?
Test in NetApp MetroCluster FC Environnement

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
